### PR TITLE
Fix headers for react native 0.40

### DIFF
--- a/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImage.h
+++ b/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImage.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Neo. All rights reserved.
 //
 
-#import "RCTView.h"
+#import <React/RCTView.h>
 #import "FLAnimatedImage.h"
 
 @class RNFLAnimatedImage;

--- a/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImage.m
+++ b/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImage.m
@@ -12,10 +12,10 @@
 #import "FLAnimatedImage.h"
 #import "RNFLAnimatedImage.h"
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import "RCTImageUtils.h"
-#import "UIView+React.h"
-#import "RCTLog.h"
+#import <React/UIView+React.h>
+#import <React/RCTLog.h>
 
 @implementation RNFLAnimatedImage  {
   

--- a/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImageManager.h
+++ b/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImageManager.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Neo. All rights reserved.
 //
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RNFLAnimatedImageManager : RCTViewManager
 

--- a/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImageManager.m
+++ b/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImageManager.m
@@ -8,8 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "RCTUIManager.h"
-#import "UIView+React.h"
+#import <React/RCTUIManager.h>
+#import <React/UIView+React.h>
 
 #import "RNFLAnimatedImageManager.h"
 #import "RNFLAnimatedImage.h"


### PR DESCRIPTION
This add compatibility for react native versions >= 0.40 but breaks it for lower versions.