### PR TITLE
Support cocoapods with use_frameworks!

### DIFF
--- a/RNFLAnimatedImage/RNFLAnimatedImage.xcodeproj/project.pbxproj
+++ b/RNFLAnimatedImage/RNFLAnimatedImage.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 					"$(SRCROOT)/../../react-native/Libraries/Image/**",
 					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/FLAnimatedImage.framework/Headers",
 					"$(SRCROOT)/../../../ios/Pods/Headers/Public/FLAnimatedImage",
+					"$(SRCROOT)/../../../ios/Pods/FLAnimatedImage/FLAnimatedImage",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -244,6 +245,7 @@
 					"$(SRCROOT)/../../react-native/Libraries/Image/**",
 					"$(SRCROOT)/../../../ios/Carthage/Build/iOS/FLAnimatedImage.framework/Headers",
 					"$(SRCROOT)/../../../ios/Pods/Headers/Public/FLAnimatedImage",
+					"$(SRCROOT)/../../../ios/Pods/FLAnimatedImage/FLAnimatedImage",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
When using the use_frameworks! option, CocoaPods doesn't put headers in `Pods/Headers/Public` - the `Pods/Headers` directory is empty, so the build fails.

The headers are in the `Pods/FLAnimatedImage/FLAnimatedImage` directory, so adding this to the header search paths makes the project build successfully in this configuration.