### PR TITLE
Resolve crash that occurs when view is not added to a superview

### DIFF
--- a/RNFLAnimatedImage/RNFLAnimatedImage.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RNFLAnimatedImage/RNFLAnimatedImage.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImage.m
+++ b/RNFLAnimatedImage/RNFLAnimatedImage/RNFLAnimatedImage.m
@@ -37,11 +37,9 @@
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 
-- (void)removeFromSuperview
+- (void)dealloc
 {
-  
   [_imageView removeObserver:self forKeyPath:@"currentFrameIndex"];
-  [super removeFromSuperview];
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
Hi! Thanks for putting this project together.

I was able to reproduce a crash that occurs when a view is initialized but not placed into the view hierarchy. 

The reason this occurs is that KVO observers in `RNFLAnimatedImage.m` are added on init, but removed only when the view is removed from it's super view. Thus, if it never get's added (and then removed) from a superview, you have a leaked observer that will fire on a zombie object - causing a native crash. 

In my manual repro tests this resolves the issue
Thanks!


